### PR TITLE
feat: `mkdir` + directory paths for `compress/decompress`

### DIFF
--- a/src/commands/compress.js
+++ b/src/commands/compress.js
@@ -2,15 +2,27 @@ import { createReadStream, createWriteStream } from "fs";
 import { createBrotliCompress, createBrotliDecompress } from "zlib";
 import * as fsExtra from "../fsExtra.js";
 import ERRORS from "../errors.js";
+import * as pathModule from "path";
+
+const BROTLI_EXTENSION = ".br";
 
 export async function compress(from, to) {
-  let fileExistsAtPath = false;
-  fileExistsAtPath = await fsExtra.isPathToValidFile(from);
+  const fileExistsAtPath = await fsExtra.isPathToValidFile(from);
   if (fileExistsAtPath) {
+    // Check if destination is a directory
+    const isDestDir = await fsExtra.isPathToValidDir(to);
+    let destinationPath = to;
+
+    if (isDestDir) {
+      // If destination is a directory, append the source filename with .br extension
+      const sourceFilename = pathModule.basename(from);
+      destinationPath = pathModule.resolve(to, `${sourceFilename}${BROTLI_EXTENSION}`);
+    }
+
     await new Promise((resolve, reject) => {
       const readStream = createReadStream(from);
       const compressStream = createBrotliCompress();
-      const writeStream = createWriteStream(to);
+      const writeStream = createWriteStream(destinationPath);
 
       // Handle errors on all streams in the pipeline
       readStream.on("error", (err) => reject(err));
@@ -28,25 +40,40 @@ export async function compress(from, to) {
 }
 
 export async function decompress(from, to) {
-  let fileExistsAtPath = false;
-  fileExistsAtPath = await fsExtra.isPathToValidFile(from);
-  if (fileExistsAtPath) {
-    await new Promise((resolve, reject) => {
-      const readStream = createReadStream(from);
-      const decompressStream = createBrotliDecompress();
-      const writeStream = createWriteStream(to);
-
-      // Handle errors on all streams in the pipeline
-      readStream.on("error", (err) => reject(err));
-      decompressStream.on("error", (err) => reject(err));
-      writeStream.on("error", (err) => reject(err));
-
-      readStream
-        .pipe(decompressStream)
-        .pipe(writeStream)
-        .on("finish", () => resolve());
-    });
-  } else {
+  const fileExistsAtPath = await fsExtra.isPathToValidFile(from);
+  if (!fileExistsAtPath) {
     throw new Error(ERRORS.invalidInput);
   }
+
+  // Validate that the file has .br extension (Brotli compressed)
+  const parsedPath = pathModule.parse(from);
+  if (parsedPath.ext !== BROTLI_EXTENSION) {
+    throw new Error(`${ERRORS.invalidInput}: File must have ${BROTLI_EXTENSION} extension for decompression`);
+  }
+
+  // Check if destination is a directory
+  const isDestDir = await fsExtra.isPathToValidDir(to);
+  let destinationPath = to;
+
+  if (isDestDir) {
+    // If destination is a directory, append the source filename (removing .br extension)
+    const sourceFilename = parsedPath.name; // filename without .br extension
+    destinationPath = pathModule.resolve(to, sourceFilename);
+  }
+
+  await new Promise((resolve, reject) => {
+    const readStream = createReadStream(from);
+    const decompressStream = createBrotliDecompress();
+    const writeStream = createWriteStream(destinationPath);
+
+    // Handle errors on all streams in the pipeline
+    readStream.on("error", (err) => reject(err));
+    decompressStream.on("error", (err) => reject(err));
+    writeStream.on("error", (err) => reject(err));
+
+    readStream
+      .pipe(decompressStream)
+      .pipe(writeStream)
+      .on("finish", () => resolve());
+  });
 }

--- a/src/commands/dirNavigation.js
+++ b/src/commands/dirNavigation.js
@@ -29,3 +29,11 @@ export async function ls(pathToDir) {
     throw new Error(ERRORS.operationFailed);
   }
 }
+
+export async function mkdir(newDirPath) {
+  try {
+    await fs.mkdir(newDirPath);
+  } catch (err) {
+    throw new Error(ERRORS.operationFailed);
+  }
+}

--- a/src/commands/fileOperations.js
+++ b/src/commands/fileOperations.js
@@ -74,7 +74,10 @@ export async function cat(path) {
 
       readable.pipe(process.stdout);
       await new Promise((resolve, reject) => {
-        readable.on("end", () => resolve());
+        readable.on("end", () => {
+          process.stdout.write('\n'); // Add newline after file content
+          resolve();
+        });
         readable.on("error", (err) => reject(err));
       });
     } catch (err) {

--- a/src/main.js
+++ b/src/main.js
@@ -21,6 +21,7 @@ export class FileManager {
       cd: this._cd.bind(this), // 1 arg
       cat: this._cat.bind(this), // 1 arg
       add: this._add.bind(this), // 1 arg
+      mkdir: this._mkdir.bind(this), // 1 arg
       cp: this._cp.bind(this), // 2 args
       ".exit": this._exit.bind(this),
       mv: this._mv.bind(this), // 2 args
@@ -135,6 +136,15 @@ export class FileManager {
     if (args.length > 0) {
       const newFilePath = this._applyNewPath(args[0]);
       await fileOperations.add(newFilePath);
+    } else {
+      throw new Error(ERRORS.invalidInput);
+    }
+  }
+
+  async _mkdir(args) {
+    if (args.length > 0) {
+      const newDirPath = this._applyNewPath(args[0]);
+      await dirNavigation.mkdir(newDirPath);
     } else {
       throw new Error(ERRORS.invalidInput);
     }


### PR DESCRIPTION
1) Added `mkdir` command - same api structure, reusing Path and Errors methods
2) Added support for Directories as paths for `compress/decompress`